### PR TITLE
Fixing Scoring to support new version

### DIFF
--- a/scoreboard/sources.yml
+++ b/scoreboard/sources.yml
@@ -52,7 +52,7 @@ sources:
     logs:
       - '{allgames,milestones}-0.{3,4,5,6}.txt'
       - '{allgames,milestones}{,-spr}-0.7.txt'
-      - '{allgames,milestones}-{0.16,0.17,0.18,0.19}.txt*'
+      - '{allgames,milestones}-{0.16,0.17,0.18}.txt*'
       - '{allgames,milestones}{,-spr,-zd}-0.{8,10,11,12,13,14,15}.txt*'
       - '{allgames,milestones}{,-spr,-zd}-svn.txt*'
     morgues:
@@ -118,7 +118,7 @@ sources:
       - clan
     base: http://underhound.eu:81/crawl/meta
     logs:
-      - '{0.16,0.17,0.18,0.19}/{logfile,milestones}{,-sprint}*'
+      - '{0.16,0.17,0.18}/{logfile,milestones}{,-sprint}*'
       - '{git,0.15,0.14,0.13,0.12,0.11,0.10}/{logfile,milestones}{,-sprint,-zotdef}*'
     morgues:
       - http://underhound.eu:81/crawl/morgue
@@ -171,6 +171,9 @@ sources:
       - meta/abyssrun/{logfile,milestones}*: abyssrun
       - meta/orcs_and_elves/{logfile,milestones}*: orcs-and-elves
       - meta/combo_god/{logfile,milestones}*: combo-god
+      - meta/adrenaline_rush/{logfile,milestones}*: adrenaline-rush
+      - meta/basajaun/{logfile,milestones}*: basajaun
+      - meta/thorn_god/{logfile,milestones}*: thorn-god
     morgues:
       - http://crawl.berotato.org/crawl/morgue
     ttyrecs:

--- a/scoreboard/sources.yml
+++ b/scoreboard/sources.yml
@@ -32,7 +32,7 @@ sources:
       - '{logfile,milestones}09'
       - '{logfile,milestones}10*'
       - '{logfile,milestones}{11,12,13,14,15,-git}{,-sprint,-zotdef}*'
-      - '{logfile,milestones}{16,17,18}{,-sprint}*'
+      - '{logfile,milestones}{16,17,18,19}{,-sprint}*'
       - '{logfile,milestones}-lorcs': lorcs
 
     # Regex -> location; player name is automatically appended.
@@ -52,7 +52,7 @@ sources:
     logs:
       - '{allgames,milestones}-0.{3,4,5,6}.txt'
       - '{allgames,milestones}{,-spr}-0.7.txt'
-      - '{allgames,milestones}-{0.16,0.17,0.18}.txt*'
+      - '{allgames,milestones}-{0.16,0.17,0.18,0.19}.txt*'
       - '{allgames,milestones}{,-spr,-zd}-0.{8,10,11,12,13,14,15}.txt*'
       - '{allgames,milestones}{,-spr,-zd}-svn.txt*'
     morgues:
@@ -118,7 +118,7 @@ sources:
       - clan
     base: http://underhound.eu:81/crawl/meta
     logs:
-      - '{0.16,0.17,0.18}/{logfile,milestones}{,-sprint}*'
+      - '{0.16,0.17,0.18,0.19}/{logfile,milestones}{,-sprint}*'
       - '{git,0.15,0.14,0.13,0.12,0.11,0.10}/{logfile,milestones}{,-sprint,-zotdef}*'
     morgues:
       - http://underhound.eu:81/crawl/morgue
@@ -140,7 +140,7 @@ sources:
     base: http://webzook.net/soup
     logs:
       - '0.16/{logfile,milestones}-old'
-      - '{0.13,0.14,0.15,0.16,0.17,0.18,trunk}/{logfile,milestones}*'
+      - '{0.13,0.14,0.15,0.16,0.17,0.18,0.19,trunk}/{logfile,milestones}*'
     morgues:
       - ['cwz.*/trunk', 'http://webzook.net/soup/morgue/trunk']
       - ['cwz.*/(\d+[.]\d+)', 'http://webzook.net/soup/morgue/$1']
@@ -151,7 +151,7 @@ sources:
     base: http://crawl.berotato.org/crawl
     logs:
       - meta/{0.15,0.14,0.13,git}/{logfile,milestones}{,-sprint,-zotdef}*
-      - meta/{0.16,0.17,0.18}/{logfile,milestones}{,-sprint}*
+      - meta/{0.16,0.17,0.18,0.19}/{logfile,milestones}{,-sprint}*
       - meta/{nostalgia,mulch_ado_about_nothing,squarelos-0.17}/{logfile,milestones}*
       - meta/evoker-god/{logfile,milestones}*: evoker-god
       - meta/bearkin/{logfile,milestones}*: bearkin
@@ -181,7 +181,7 @@ sources:
     base: http://crawl.xtahua.com/crawl/meta
     logs:
       - '{git,0.14,0.15}/{logfile,milestones}{,-sprint,-zotdef}*'
-      - '{0.16,0.17,0.18}/{logfile,milestones}{,-sprint}*'
+      - '{0.16,0.17,0.18,0.19}/{logfile,milestones}{,-sprint}*'
     morgues:
       - http://crawl.xtahua.com/crawl/morgue
     ttyrecs:
@@ -191,7 +191,7 @@ sources:
     base: http://lazy-life.ddo.jp/mirror/meta
     logs:
       - '{trunk,0.14}/{logfile,milestones}{,-sprint,-zotdef}*'
-      - '{0.15,0.16,0.17,0.18}/{logfile,milestones}*'
+      - '{0.15,0.16,0.17,0.18,0.19}/{logfile,milestones}*'
     morgues:
       - [ 'lld.*/(0.\d+)', 'http://lazy-life.ddo.jp:8080/morgue-$1' ]
       - http://lazy-life.ddo.jp:8080/morgue
@@ -201,7 +201,7 @@ sources:
   - name: cpo
     base: https://crawl.project357.org
     logs:
-      - dcss-{milestones,logfiles}-{trunk,0.15,0.16,0.17,0.18,combo_god}*
+      - dcss-{milestones,logfiles}-{trunk,0.15,0.16,0.17,0.18,0.19,combo_god}*
     morgues:
       - https://crawl.project357.org/morgue
     ttyrecs:


### PR DESCRIPTION
Urls that work:
* http://crawl.akrasiac.org/logfile19
* http://webzook.net/soup/0.19/logfile
* http://crawl.xtahua.com/crawl/meta/0.19/logfile
* http://crawl.berotato.org/crawl/meta/0.19/logfile
* http://lazy-life.ddo.jp/mirror/meta/0.19/logfile
* https://crawl.project357.org/dcss-logfiles-0.19

Doesn't work yet (but anticipate it will eventually and doesn't seem to hurt):
* http://underhound.eu:81/crawl/meta/0.19/logfile
* https://crawl.jorgrun.rocks/meta/0.19/logfile (this is also hilarious)